### PR TITLE
Initialize PromptBuilder in EdenSystem

### DIFF
--- a/lib/core/eden_system.dart
+++ b/lib/core/eden_system.dart
@@ -7,6 +7,7 @@ import 'package:edenroot/core/will/free_will_engine.dart';
 import 'package:edenroot/core/will/desire_scheduler.dart';
 import 'package:edenroot/idle/idle_loop.dart';
 import 'package:edenroot/core/grounding/emotional_grounding_engine.dart';
+import 'package:edenroot/core/voice/prompt_builder.dart';
 
 abstract class EdenSystem {
   EmotionEngine get emotionEngine;
@@ -18,4 +19,5 @@ abstract class EdenSystem {
   DesireScheduler get desireScheduler;
   IdleLoop get idleLoop;
   EmotionalGroundingEngine get groundingEngine;
+  PromptBuilder get promptBuilder;
 }

--- a/lib/core/voice/prompt_builder.dart
+++ b/lib/core/voice/prompt_builder.dart
@@ -306,7 +306,6 @@ enum PromptType {
 
 /// Extension methods for cleaner API
 extension PromptBuilderExtensions on EdenSystem {
-  PromptBuilder get promptBuilder => PromptBuilder(this);
   
   String buildPromptFor(PromptType type, {String? userId}) {
     return promptBuilder.buildPrompt(


### PR DESCRIPTION
## Summary
- expose PromptBuilder on `EdenSystem`
- remove extension getter that recreated a new PromptBuilder each call
- keep EdenBrain initializing `promptBuilder` during setup

## Testing
- `dart format lib/core/eden_system.dart lib/core/voice/prompt_builder.dart lib/discord/prompt_server.dart` *(fails: `dart: command not found`)*
- `dart analyze` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684425cde5308331b2e3b84d467260e9