### PR TITLE
Introduce memory interpreter for prompts

### DIFF
--- a/docs/features/memory_interpreter.md
+++ b/docs/features/memory_interpreter.md
@@ -1,0 +1,15 @@
+# Memory Interpreter
+
+The memory interpreter provides a thin layer between the prompt builder and the
+memory store. It selects memories for a given prompt type and user context so
+that prompts can stay concise while still drawing from meaningful experiences.
+
+## Capabilities
+- Fetches memories from `MemoryManager` based on `PromptType`.
+- Offers quick summaries for embedding directly in prompts.
+- Centralises memory selection logic so future refinement happens in one place.
+
+## Usage
+The `PromptBuilder` now calls `system.memoryInterpreter.fetchForPrompt` instead
+of querying the `MemoryManager` directly. This keeps prompt generation focused
+on interpretation rather than raw retrieval.

--- a/lib/core/eden_system.dart
+++ b/lib/core/eden_system.dart
@@ -8,6 +8,7 @@ import 'package:edenroot/core/will/desire_scheduler.dart';
 import 'package:edenroot/idle/idle_loop.dart';
 import 'package:edenroot/core/grounding/emotional_grounding_engine.dart';
 import 'package:edenroot/core/voice/prompt_builder.dart';
+import 'package:edenroot/core/memory/memory_interpreter.dart';
 
 abstract class EdenSystem {
   EmotionEngine get emotionEngine;
@@ -20,4 +21,5 @@ abstract class EdenSystem {
   IdleLoop get idleLoop;
   EmotionalGroundingEngine get groundingEngine;
   PromptBuilder get promptBuilder;
+  MemoryInterpreter get memoryInterpreter;
 }

--- a/lib/core/memory/memory_interpreter.dart
+++ b/lib/core/memory/memory_interpreter.dart
@@ -1,0 +1,49 @@
+// lib/core/memory/memory_interpreter.dart
+
+/*
+MemoryInterpreter — Provides contextual memory retrieval for prompt generation.
+
+- Fetches relevant MemoryRecord objects based on prompt type and user context.
+- Converts memories into short summaries for embedding into prompts.
+- Phase 6 Utility — Bridges MemoryManager and PromptBuilder.
+*/
+
+import 'package:edenroot/models/memory_record.dart';
+import 'package:edenroot/core/voice/prompt_builder.dart' show PromptType;
+import 'memory_manager.dart';
+
+class MemoryInterpreter {
+  final MemoryManager memoryManager;
+
+  MemoryInterpreter(this.memoryManager);
+
+  /// Fetch memories suited for a given prompt type.
+  List<MemoryRecord> fetchForPrompt(PromptType type, {String? userId}) {
+    switch (type) {
+      case PromptType.conversation:
+        if (userId != null) {
+          return memoryManager.fromUser(userId).take(5).toList();
+        }
+        return memoryManager.getRecent(limit: 5);
+      case PromptType.reflection:
+      case PromptType.dream:
+        return memoryManager
+            .filterByEmotion(0.2, 1.0)
+            .take(3)
+            .toList();
+      case PromptType.morning:
+        return memoryManager.recent(maxAge: 1);
+      default:
+        return memoryManager
+            .filterByEmotion(0.3, 1.0)
+            .take(3)
+            .toList();
+    }
+  }
+
+  /// Return memory summaries for quick prompt embedding.
+  List<String> summariesForPrompt(PromptType type, {String? userId}) {
+    final memories = fetchForPrompt(type, userId: userId);
+    return memories.map((m) => m.summary).toList();
+  }
+}

--- a/lib/core/voice/prompt_builder.dart
+++ b/lib/core/voice/prompt_builder.dart
@@ -201,27 +201,11 @@ Foundational values (your ethical soil):
   /// Helper methods
   
   List<MemoryRecord> _getRelevantMemories(PromptType promptType, String? userId) {
-    // Use only available MemoryManager methods
-    switch (promptType) {
-      case PromptType.conversation:
-        if (userId != null) {
-          return system.memoryManager.fromUser(userId, applyResonance: false).take(5).toList();
-        }
-        return system.memoryManager.getRecent(limit: 5, applyResonance: false);
-        
-      case PromptType.reflection:
-      case PromptType.dream:
-        // Use memories with highest positive valence as "emotionally resonant"
-        return system.memoryManager.filterByEmotion(0.2, 1.0, applyResonance: false).take(3).toList();
-        
-      case PromptType.morning:
-        // Use today's memories
-        return system.memoryManager.recent(maxAge: 1, applyResonance: false);
-        
-      default:
-        // Use recent significant (highest valence) memories
-        return system.memoryManager.filterByEmotion(0.3, 1.0, applyResonance: false).take(3).toList();
-    }
+    // Delegate retrieval to MemoryInterpreter for centralized logic
+    return system.memoryInterpreter.fetchForPrompt(
+      promptType,
+      userId: userId,
+    );
   }
   
   String _describeEmotionalState(double mood, EmotionType dominant) {

--- a/lib/discord/prompt_server.dart
+++ b/lib/discord/prompt_server.dart
@@ -31,6 +31,7 @@ import 'package:edenroot/core/relationships/relationship_profile.dart';
 import 'package:edenroot/models/memory_record.dart';
 import 'package:edenroot/utils/dev_logger.dart';
 import 'package:edenroot/utils/memory_logger.dart';
+import 'package:edenroot/core/memory/memory_interpreter.dart';
 import 'package:edenroot/idle/idle_loop.dart';
 import 'package:edenroot/infrastructure/sync/sync_manager.dart';
 import 'package:edenroot/core/persistence/eden_state_manager.dart'; // NEW
@@ -48,6 +49,7 @@ class EdenBrain implements EdenSystem {
   late final DesireScheduler desireScheduler;
   late final NarrativeSurface narrativeSurface;
   late final MemoryLogger memoryLogger;
+  late final MemoryInterpreter memoryInterpreter;
   late final IdleLoop idleLoop;
   late final SyncManager syncManager;
   late final EmotionalGroundingEngine groundingEngine;
@@ -107,6 +109,8 @@ class EdenBrain implements EdenSystem {
       selfModel: selfModel,
       groundingEngine: groundingEngine,
     );
+
+    memoryInterpreter = MemoryInterpreter(memoryManager);
 
     promptBuilder = PromptBuilder(this);
 


### PR DESCRIPTION
## Summary
- create `MemoryInterpreter` for contextual memory retrieval
- expose it through `EdenSystem` and initialize in `EdenBrain`
- use the interpreter in `PromptBuilder`
- document the feature

## Testing
- `dart format lib/core/memory/memory_interpreter.dart lib/core/eden_system.dart lib/core/voice/prompt_builder.dart lib/discord/prompt_server.dart docs/features/memory_interpreter.md` *(fails: `dart` not found)*
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444dd355c4833184481e8d105e5155